### PR TITLE
deb: Release icinga2 2.7.1-2

### DIFF
--- a/icinga2/stretch/debian/changelog
+++ b/icinga2/stretch/debian/changelog
@@ -1,3 +1,9 @@
+icinga2 (2.7.1-2) icinga-stretch; urgency=medium
+
+  * Increase systemd TasksMax to infinity
+
+ -- Markus Frosch <markus.frosch@icinga.com>  Mon, 02 Oct 2017 10:21:15 +0200
+
 icinga2 (2.7.1-1) icinga-stretch; urgency=medium
 
   * Update to 2.7.1

--- a/icinga2/stretch/debian/icinga2-common.install
+++ b/icinga2/stretch/debian/icinga2-common.install
@@ -1,4 +1,5 @@
 debian/config/apt.conf        etc/icinga2/conf.d
+debian/icinga2.service.d      etc/systemd/system
 debian/tmp/etc/icinga2
 debian/tmp/etc/logrotate.d
 tools/syntax/nano/icinga2.nanorc usr/share/nano

--- a/icinga2/stretch/debian/icinga2.service.d/limits.conf
+++ b/icinga2/stretch/debian/icinga2.service.d/limits.conf
@@ -1,0 +1,9 @@
+# Icinga 2 sets some default values to extend OS defaults
+#
+# Please refer to our troubleshooting documentations for details
+# and reasons on these values.
+[Service]
+TasksMax=infinity
+
+# May also cause problems, uncomment if you have any
+#LimitNPROC=62883

--- a/icinga2/ubuntu/debian/changelog
+++ b/icinga2/ubuntu/debian/changelog
@@ -1,3 +1,9 @@
+icinga2 (2.7.1-2) icinga-ubuntu; urgency=medium
+
+  * Increase systemd TasksMax to infinity
+
+ -- Markus Frosch <markus.frosch@icinga.com>  Mon, 02 Oct 2017 10:21:15 +0200
+
 icinga2 (2.7.1-1) icinga-ubuntu; urgency=medium
 
   * Update to 2.7.1

--- a/icinga2/ubuntu/debian/icinga2-common.install
+++ b/icinga2/ubuntu/debian/icinga2-common.install
@@ -1,4 +1,5 @@
 debian/config/apt.conf        etc/icinga2/conf.d
+debian/icinga2.service.d      etc/systemd/system
 debian/tmp/etc/icinga2
 debian/tmp/etc/logrotate.d
 tools/syntax/nano/icinga2.nanorc usr/share/nano

--- a/icinga2/ubuntu/debian/icinga2.service.d/limits.conf
+++ b/icinga2/ubuntu/debian/icinga2.service.d/limits.conf
@@ -1,0 +1,9 @@
+# Icinga 2 sets some default values to extend OS defaults
+#
+# Please refer to our troubleshooting documentations for details
+# and reasons on these values.
+[Service]
+TasksMax=infinity
+
+# May also cause problems, uncomment if you have any
+#LimitNPROC=62883


### PR DESCRIPTION
To be released for:

* Debian stretch
* Ubuntu >= xenial

Also see: https://github.com/Icinga/icinga2/issues/5611