### PR TITLE
rpm: Release icinga2 2.7.1-2

### DIFF
--- a/icinga2/icinga2.service.limits.conf
+++ b/icinga2/icinga2.service.limits.conf
@@ -1,0 +1,9 @@
+# Icinga 2 sets some default values to extend OS defaults
+#
+# Please refer to our troubleshooting documentations for details
+# and reasons on these values.
+[Service]
+TasksMax=infinity
+
+# May also cause problems, uncomment if you have any
+#LimitNPROC=62883

--- a/icinga2/icinga2.spec
+++ b/icinga2/icinga2.spec
@@ -57,7 +57,7 @@
 %define apachegroup www
 %if 0%{?suse_version} >= 1310
 %define use_systemd 1
-%if 0%{?suse_version} >= 120200 && 0%{?is_opensuse}
+%if 0%{?leap_version} >= 420100
 # for installing limits.conf on systemd >= 228
 %define configure_systemd_limits 1
 %else

--- a/icinga2/icinga2.spec
+++ b/icinga2/icinga2.spec
@@ -842,3 +842,5 @@ fi
 %{_datadir}/nano/%{name}.nanorc
 
 %changelog
+* Tue Jun 20 2017 Markus Frosch <markus.frosch@icinga.com> 2.7.0-1
+- Update to 2.7.0

--- a/icinga2/icinga2.spec
+++ b/icinga2/icinga2.spec
@@ -417,8 +417,8 @@ install -D -m 0644 etc/icinga/icinga-classic-apache.conf %{buildroot}%{apachecon
 # install custom limits.conf for systemd
 %if 0%{?configure_systemd_limits}
 # for > 2.8 or > 2.7.2
-#install -D -m 0644 etc/initsystem/icinga2.service.limits.conf %%{buildroot}%%{_userunitdir}/%%{name}.service.d/limits.conf
-install -D -m 0644 %{SOURCE1} %{buildroot}%{_userunitdir}/%{name}.service.d/limits.conf
+#install -D -m 0644 etc/initsystem/icinga2.service.limits.conf %%{buildroot}/etc/systemd/system/%%{name}.service.d/limits.conf
+install -D -m 0644 %{SOURCE1} %{buildroot}/etc/systemd/system/%{name}.service.d/limits.conf
 %endif
 
 # remove features-enabled symlinks
@@ -739,7 +739,7 @@ fi
 %if 0%{?use_systemd}
 %attr(644,root,root) %{_unitdir}/%{name}.service
 %if 0%{?configure_systemd_limits}
-%attr(644,root,root) %{_userunitdir}/%{name}.service.d/limits.conf
+%attr(644,root,root) /etc/systemd/system/%{name}.service.d/limits.conf
 %endif
 %else
 %attr(755,root,root) %{_sysconfdir}/init.d/%{name}

--- a/icinga2/icinga2.spec
+++ b/icinga2/icinga2.spec
@@ -17,7 +17,7 @@
 # * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.             *
 # ******************************************************************************/
 
-%define revision 1
+%define revision 2
 
 # make sure that _rundir is working on older systems
 %if ! %{defined _rundir}
@@ -842,5 +842,11 @@ fi
 %{_datadir}/nano/%{name}.nanorc
 
 %changelog
+* Tue Sep 20 2017 Markus Frosch <markus.frosch@icinga.com> 2.7.1-2
+- Fixing systemd limit issues on openSUSE > 42.1
+
+* Thu Sep 21 2017 Michael Friedrich <michael.friedrich@icinga.com> 2.7.1-1
+- Update to 2.7.1
+
 * Tue Jun 20 2017 Markus Frosch <markus.frosch@icinga.com> 2.7.0-1
 - Update to 2.7.0

--- a/icinga2/icinga2.spec
+++ b/icinga2/icinga2.spec
@@ -416,7 +416,9 @@ install -D -m 0644 etc/icinga/icinga-classic-apache.conf %{buildroot}%{apachecon
 
 # install custom limits.conf for systemd
 %if 0%{?configure_systemd_limits}
-install -D -m 0644 etc/initsystem/icinga2.service.limits.conf %{buildroot}%{_userunitdir}/%{name}.service.d/limits.conf
+# for > 2.8 or > 2.7.2
+#install -D -m 0644 etc/initsystem/icinga2.service.limits.conf %%{buildroot}%%{_userunitdir}/%%{name}.service.d/limits.conf
+install -D -m 0644 %{SOURCE1} %{buildroot}%{_userunitdir}/%{name}.service.d/limits.conf
 %endif
 
 # remove features-enabled symlinks


### PR DESCRIPTION
To be released for:

* openSUSE >= 42.2

Also see: https://github.com/Icinga/icinga2/issues/5611