### PR TITLE
WIP: RPM changes for icingaweb2 2.5.0

### DIFF
--- a/icingaweb2/icingaweb2.spec
+++ b/icingaweb2/icingaweb2.spec
@@ -100,6 +100,9 @@ Group:                          Applications/System
 %{?fedora:Requires(pre):        shadow-utils}
 %{?rhel:Requires(pre):          shadow-utils}
 %{?suse_version:Requires(pre):  pwdutils}
+%if 0%{?suse_version} > 1320
+Requires(pre):                  system-user-wwwrun
+%endif
 
 %description common
 Common files for Icinga Web 2 and the Icinga CLI

--- a/icingaweb2/icingaweb2.spec
+++ b/icingaweb2/icingaweb2.spec
@@ -25,7 +25,7 @@ Packager:       Icinga Team <info@icinga.com>
 %endif
 
 # minimum required PHP version
-%define php_version 5.3.0
+%define php_version 5.6.0
 
 %if 0%{?suse_version}
 %define wwwconfigdir    %{_sysconfdir}/apache2/conf.d

--- a/icingaweb2/icingaweb2.spec
+++ b/icingaweb2/icingaweb2.spec
@@ -112,8 +112,8 @@ Common files for Icinga Web 2 and the Icinga CLI
 Summary:                    Icinga Web 2 PHP library
 Group:                      Development/Libraries
 Requires:                   %{php_common} >= %{php_version}
-Requires:                   %{php}-gd %{php}-intl
-%{?rhel:Requires:           %{php}-pdo}
+Requires:                   %{php}-gd %{php}-intl %{php}-mbstring
+%{?rhel:Requires:           %{php}-pdo %{php}-xml}
 Requires:                   %{name}-vendor-zf1 = %{version}-%{release}
 %{?amzn:Requires:           %{php}-pecl-imagick}
 %{?fedora:Requires:         php-pecl-imagick}

--- a/icingaweb2/icingaweb2.spec
+++ b/icingaweb2/icingaweb2.spec
@@ -1,4 +1,4 @@
-# Icinga Web 2 | (c) 2013-2016 Icinga Development Team | GPLv2+
+# Icinga Web 2 | (c) 2013-2017 Icinga Development Team | GPLv2+
 
 %define revision 1
 
@@ -15,28 +15,41 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}
 Packager:       Icinga Team <info@icinga.com>
 
 %if 0%{?fedora} || 0%{?rhel} || 0%{?amzn}
+%define php_runtime     %{php}
+
 %define php             php
 %define php_cli         php-cli
+%define php_common      php-common
 %define wwwconfigdir    %{_sysconfdir}/httpd/conf.d
 %define wwwuser         apache
 %endif
+
+# minimum required PHP version
+%define php_version 5.3.0
 
 %if 0%{?suse_version}
 %define wwwconfigdir    %{_sysconfdir}/apache2/conf.d
 %define wwwuser         wwwrun
 %if 0%{?suse_version} == 1110
-%define php php53
-Requires: apache2-mod_php53
+%define php             php53
+%define php_runtime     apache2-mod_php53
 %else
-%define php php5
-Requires: apache2-mod_php5
+# TODO: php7 on 12
+%define php             php5
+%define php_runtime     apache2-mod_php5
 %endif
+%define php_common      %{php}
 %endif
 
 %{?amzn:Requires(pre):          shadow-utils}
 %{?fedora:Requires(pre):        shadow-utils}
 %{?rhel:Requires(pre):          shadow-utils}
 %{?suse_version:Requires(pre):  pwdutils}
+
+Requires:                       %{php_runtime} >= %{php_version}
+Requires:                       %{php_common} >= %{php_version}
+
+Requires:                       icingacli = %{version}-%{release}
 Requires:                       %{name}-common = %{version}-%{release}
 Requires:                       php-Icinga = %{version}-%{release}
 Requires:                       %{name}-vendor-dompdf = %{version}-%{release}
@@ -79,7 +92,7 @@ Common files for Icinga Web 2 and the Icinga CLI
 %package -n php-Icinga
 Summary:                    Icinga Web 2 PHP library
 Group:                      Development/Libraries
-Requires:                   %{php} >= 5.3.0
+Requires:                   %{php_common} >= %{php_version}
 Requires:                   %{php}-gd %{php}-intl
 Requires:                   %{name}-vendor-zf1 = %{version}-%{release}
 %{?amzn:Requires:           %{php}-pecl-imagick}
@@ -96,10 +109,11 @@ Summary:                    Icinga CLI
 Group:                      Applications/System
 Requires:                   %{name}-common = %{version}-%{release}
 Requires:                   php-Icinga = %{version}-%{release}
-%{?amzn:Requires:           %{php_cli} >= 5.3.0 bash-completion}
-%{?fedora:Requires:         %{php_cli} >= 5.3.0 bash-completion}
-%{?rhel:Requires:           %{php_cli} >= 5.3.0 bash-completion}
-%{?suse_version:Requires:   %{php} >= 5.3.0}
+%{?amzn:Requires:           %{php_cli} >= %{php_version} bash-completion}
+%{?fedora:Requires:         %{php_cli} >= %{php_version} bash-completion}
+%{?rhel:Requires:           %{php_cli} >= %{php_version} bash-completion}
+# TODO: cli package for SUSE?
+%{?suse_version:Requires:   %{php_common} >= %{php_version}}
 
 %description -n icingacli
 Icinga CLI
@@ -125,7 +139,7 @@ SELinux policy for Icinga Web 2
 Summary:    Icinga Web 2 vendor library dompdf
 Group:      Development/Libraries
 License:    LGPLv2.1
-Requires:   %{php} >= 5.3.0
+Requires:   %{php_common} >= %{php_version}
 
 %description vendor-dompdf
 Icinga Web 2 vendor library dompdf
@@ -136,7 +150,7 @@ Epoch:      1
 Summary:    Icinga Web 2 vendor library HTMLPurifier
 Group:      Development/Libraries
 License:    LGPLv2.1
-Requires:   %{php} >= 5.3.0
+Requires:   %{php_common} >= %{php_version}
 
 %description vendor-HTMLPurifier
 Icinga Web 2 vendor library HTMLPurifier
@@ -146,7 +160,7 @@ Icinga Web 2 vendor library HTMLPurifier
 Summary:    Icinga Web 2 vendor library JShrink
 Group:      Development/Libraries
 License:    BSD
-Requires:   %{php} >= 5.3.0
+Requires:   %{php_common} >= %{php_version}
 
 %description vendor-JShrink
 Icinga Web 2 vendor library JShrink
@@ -156,7 +170,7 @@ Icinga Web 2 vendor library JShrink
 Summary:    Icinga Web 2 vendor library lessphp
 Group:      Development/Libraries
 License:    MIT
-Requires:   %{php} >= 5.3.0
+Requires:   %{php_common} >= %{php_version}
 
 %description vendor-lessphp
 Icinga Web 2 vendor library lessphp
@@ -166,7 +180,7 @@ Icinga Web 2 vendor library lessphp
 Summary:    Icinga Web 2 vendor library Parsedown
 Group:      Development/Libraries
 License:    MIT
-Requires:   %{php} >= 5.3.0
+Requires:   %{php_common} >= %{php_version}
 
 %description vendor-Parsedown
 Icinga Web 2 vendor library Parsedown
@@ -176,7 +190,7 @@ Icinga Web 2 vendor library Parsedown
 Summary:    Icinga Web 2's fork of Zend Framework 1
 Group:      Development/Libraries
 License:    BSD
-Requires:   %{php} >= 5.3.0
+Requires:   %{php_common} >= %{php_version}
 Obsoletes:  %{name}-vendor-Zend < 1.12.20
 
 %description vendor-zf1

--- a/icingaweb2/icingaweb2.spec
+++ b/icingaweb2/icingaweb2.spec
@@ -26,6 +26,7 @@ Packager:       Icinga Team <info@icinga.com>
 %define php_scl_prefix  %{php_scl}-
 %define php_runtime     %{php_scl_prefix}php-fpm
 %define php_bin         /opt/rh/%{php_scl}/root/usr/bin/php
+%define php_fpm         1
 %else
 %define php_runtime     %{php}
 %endif
@@ -238,7 +239,11 @@ cp -prv modules/{monitoring,setup,doc,translation} %{buildroot}/%{basedir}/modul
 cp -prv library/Icinga %{buildroot}/%{phpdir}
 cp -prv library/vendor/{dompdf,HTMLPurifier*,JShrink,lessphp,Parsedown,Zend} %{buildroot}/%{basedir}/library/vendor
 cp -prv public/{css,font,img,js,error_norewrite.html} %{buildroot}/%{basedir}/public
+%if 0%{?php_fpm:1}
+cp -pv packages/files/apache/icingaweb2.fpm.conf %{buildroot}/%{wwwconfigdir}/icingaweb2.conf
+%else
 cp -pv packages/files/apache/icingaweb2.conf %{buildroot}/%{wwwconfigdir}/icingaweb2.conf
+%endif
 cp -pv packages/files/bin/icingacli %{buildroot}/%{bindir}
 %if 0%{?php_bin:1}
 sed -i '1 s~#!.*~#!%{php_bin}~' %{buildroot}/%{bindir}/icingacli

--- a/icingaweb2/icingaweb2.spec
+++ b/icingaweb2/icingaweb2.spec
@@ -48,11 +48,11 @@ Packager:       Icinga Team <info@icinga.com>
 %define php             php53
 %define php_runtime     apache2-mod_php53
 %else
-# TODO: php7 on 12
-%define php             php5
-%define php_runtime     apache2-mod_php5
+%define php             php
+%define php_runtime     mod_php_any
 %endif
 %define php_common      %{php}
+%define php_cli         %{php}
 %endif
 
 %{?amzn:Requires(pre):          shadow-utils}
@@ -123,11 +123,8 @@ Summary:                    Icinga CLI
 Group:                      Applications/System
 Requires:                   %{name}-common = %{version}-%{release}
 Requires:                   php-Icinga = %{version}-%{release}
-%{?amzn:Requires:           %{php_cli} >= %{php_version} bash-completion}
-%{?fedora:Requires:         %{php_cli} >= %{php_version} bash-completion}
-%{?rhel:Requires:           %{php_cli} >= %{php_version} bash-completion}
-# TODO: cli package for SUSE?
-%{?suse_version:Requires:   %{php_common} >= %{php_version}}
+Requires:                   bash-completion
+Requires:                   %{php_cli} >= %{php_version}
 
 %description -n icingacli
 Icinga CLI

--- a/icingaweb2/icingaweb2.spec
+++ b/icingaweb2/icingaweb2.spec
@@ -48,6 +48,10 @@ Packager:       Icinga Team <info@icinga.com>
 %define php_runtime     mod_php_any
 %define php_common      %{php}
 %define php_cli         %{php}
+# conflict with older PHP on SLES and openSUSE
+Conflicts:              php < %{php_version}
+Conflicts:              php5 < %{php_version}
+Conflicts:              php53
 %endif
 
 %{?amzn:Requires(pre):          shadow-utils}
@@ -120,6 +124,13 @@ Requires:                   %{name}-common = %{version}-%{release}
 Requires:                   php-Icinga = %{version}-%{release}
 Requires:                   bash-completion
 Requires:                   %{php_cli} >= %{php_version}
+%if 0%{?suse_version}
+# conflict with older PHP on SLES and openSUSE
+Conflicts:                  php < %{php_version}
+Conflicts:                  php5 < %{php_version}
+Conflicts:                  php53
+%endif
+
 
 %description -n icingacli
 Icinga CLI

--- a/icingaweb2/icingaweb2.spec
+++ b/icingaweb2/icingaweb2.spec
@@ -61,6 +61,9 @@ Conflicts:              php53
 
 Requires:                       %{php_runtime} >= %{php_version}
 Requires:                       %{php_common} >= %{php_version}
+%if 0%{?suse_version}
+Requires:                       apache2
+%endif
 
 Requires:                       icingacli = %{version}-%{release}
 Requires:                       %{name}-common = %{version}-%{release}

--- a/icingaweb2/icingaweb2.spec
+++ b/icingaweb2/icingaweb2.spec
@@ -151,6 +151,7 @@ Summary:    Icinga Web 2 vendor library dompdf
 Group:      Development/Libraries
 License:    LGPLv2.1
 Requires:   %{php_common} >= %{php_version}
+Requires:   %{name}-common = %{version}-%{release}
 
 %description vendor-dompdf
 Icinga Web 2 vendor library dompdf
@@ -162,6 +163,7 @@ Summary:    Icinga Web 2 vendor library HTMLPurifier
 Group:      Development/Libraries
 License:    LGPLv2.1
 Requires:   %{php_common} >= %{php_version}
+Requires:   %{name}-common = %{version}-%{release}
 
 %description vendor-HTMLPurifier
 Icinga Web 2 vendor library HTMLPurifier
@@ -172,6 +174,7 @@ Summary:    Icinga Web 2 vendor library JShrink
 Group:      Development/Libraries
 License:    BSD
 Requires:   %{php_common} >= %{php_version}
+Requires:   %{name}-common = %{version}-%{release}
 
 %description vendor-JShrink
 Icinga Web 2 vendor library JShrink
@@ -182,6 +185,7 @@ Summary:    Icinga Web 2 vendor library lessphp
 Group:      Development/Libraries
 License:    MIT
 Requires:   %{php_common} >= %{php_version}
+Requires:   %{name}-common = %{version}-%{release}
 
 %description vendor-lessphp
 Icinga Web 2 vendor library lessphp
@@ -192,6 +196,7 @@ Summary:    Icinga Web 2 vendor library Parsedown
 Group:      Development/Libraries
 License:    MIT
 Requires:   %{php_common} >= %{php_version}
+Requires:   %{name}-common = %{version}-%{release}
 
 %description vendor-Parsedown
 Icinga Web 2 vendor library Parsedown
@@ -203,6 +208,7 @@ Group:      Development/Libraries
 License:    BSD
 Requires:   %{php_common} >= %{php_version}
 Obsoletes:  %{name}-vendor-Zend < 1.12.20
+Requires:   %{name}-common = %{version}-%{release}
 
 %description vendor-zf1
 Icinga Web 2's fork of Zend Framework 1
@@ -283,6 +289,11 @@ rm -rf %{buildroot}
 %{basedir}/doc
 %{basedir}/modules
 %{basedir}/public
+%if 0%{?suse_version}
+# for lint on OBS
+%dir %{dirname:%{wwwconfigdir}}
+%dir %{wwwconfigdir}
+%endif
 %config(noreplace) %{wwwconfigdir}/icingaweb2.conf
 %attr(2775,root,%{icingawebgroup}) %dir %{logdir}
 %attr(2770,root,%{icingawebgroup}) %config(noreplace) %dir %{configdir}/modules/setup
@@ -299,14 +310,22 @@ exit 0
 
 %files common
 %defattr(-,root,root)
-%{basedir}/application/locale
+%dir %{basedir}
+%dir %{basedir}/application
+%dir %{basedir}/library
+%dir %{basedir}/library/vendor
 %dir %{basedir}/modules
+%{basedir}/application/locale
 %attr(2770,root,%{icingawebgroup}) %config(noreplace) %dir %{configdir}
 %attr(2770,root,%{icingawebgroup}) %config(noreplace) %dir %{configdir}/modules
 
 
 %files -n php-Icinga
 %defattr(-,root,root)
+%if 0%{?suse_version}
+# for lint on OBS
+%dir %{phpdir}
+%endif
 %{phpdir}/Icinga
 
 

--- a/icingaweb2/icingaweb2.spec
+++ b/icingaweb2/icingaweb2.spec
@@ -44,13 +44,8 @@ Packager:       Icinga Team <info@icinga.com>
 %if 0%{?suse_version}
 %define wwwconfigdir    %{_sysconfdir}/apache2/conf.d
 %define wwwuser         wwwrun
-%if 0%{?suse_version} == 1110
-%define php             php53
-%define php_runtime     apache2-mod_php53
-%else
 %define php             php
 %define php_runtime     mod_php_any
-%endif
 %define php_common      %{php}
 %define php_cli         %{php}
 %endif


### PR DESCRIPTION
Changes include:
- [x] Require PHP 7.1 / 7.0 via SCL on el7 and el6
- [x] Raise PHP version requirement to >= 5.6.0
- [x] Test el6 and el7 (locally)
- [x] Test SLES 12 / OpenSUSE 42.3
  * Add version conflict to avoid older PHP versions

Minor changes:
- [x] Minor macro and requirement improvements
  * php_runtime
  * php_version
- [x] Dependency improvements for SUSE

Notes:
* SUSE seems to require a `Conflicts` rule to avoid installing PHP < 5.6

Also see: https://github.com/Icinga/icingaweb2/pull/3094