### PR TITLE
Icinga Web 2: FPM: Support both Apache >= 2.4 and Apache < 2.4

### DIFF
--- a/icingaweb2/icingaweb2-fix-apache-fpm-config.patch
+++ b/icingaweb2/icingaweb2-fix-apache-fpm-config.patch
@@ -1,0 +1,35 @@
+commit 65ea398ff43bdae24055390e1686c049068a367e
+Author: Eric Lippmann <eric.lippmann@icinga.com>
+Date:   Tue Nov 28 09:12:51 2017 +0100
+
+    Remove superfluous LocationMatch block from the Apache FPM config
+
+diff --git a/packages/files/apache/icingaweb2.fpm.conf b/packages/files/apache/icingaweb2.fpm.conf
+index defdf2bbb..fce026e45 100644
+--- a/packages/files/apache/icingaweb2.fpm.conf
++++ b/packages/files/apache/icingaweb2.fpm.conf
+@@ -1,15 +1,5 @@
+ Alias /icingaweb2 "/usr/share/icingaweb2/public"
+ 
+-# forwarding PHP requests to FPM
+-<LocationMatch "^/icingaweb2/(.*\.php)$">
+-    ProxyPassMatch "fcgi://127.0.0.1:9000/usr/share/icingaweb2/public/$1"
+-    <IfModule mod_authz_core.c>
+-        # Apache 2.4
+-        ProxyErrorOverride on
+-        ErrorDocument 503 /icingaweb2/error_unavailable.html
+-    </IfModule>
+-</LocationMatch>
+-
+ <Directory "/usr/share/icingaweb2/public">
+     Options SymLinksIfOwnerMatch
+     AllowOverride None
+@@ -48,7 +38,7 @@ Alias /icingaweb2 "/usr/share/icingaweb2/public"
+         ErrorDocument 404 /icingaweb2/error_norewrite.html
+     </IfModule>
+ 
+-    # forwarding PHP requests to FPM
++    # Forward PHP requests to FPM
+     <FilesMatch "\.php$">
+         SetHandler "proxy:fcgi://127.0.0.1:9000"
+         ErrorDocument 503 /icingaweb2/error_unavailable.html

--- a/icingaweb2/icingaweb2-fix-apache22-fpm-config.patch
+++ b/icingaweb2/icingaweb2-fix-apache22-fpm-config.patch
@@ -1,0 +1,40 @@
+commit ae86dd298706b20d58200a49d04d56bd8c1b0419
+Author: Eric Lippmann <eric.lippmann@icinga.com>
+Date:   Wed Nov 29 14:31:18 2017 +0100
+
+    FPM Config: Support Apache < 2.4
+
+diff --git a/packages/files/apache/icingaweb2.fpm.conf b/packages/files/apache/icingaweb2.fpm.conf
+index fce026e45..9f01c214b 100644
+--- a/packages/files/apache/icingaweb2.fpm.conf
++++ b/packages/files/apache/icingaweb2.fpm.conf
+@@ -1,5 +1,12 @@
+ Alias /icingaweb2 "/usr/share/icingaweb2/public"
+ 
++<IfVersion < 2.4>
++    # Forward PHP requests to FPM
++    <LocationMatch "^/icingaweb2/(.*\.php)$">
++        ProxyPassMatch "fcgi://127.0.0.1:9000/usr/share/icingaweb2/public/$1"
++    </LocationMatch>
++</IfVersion>
++
+ <Directory "/usr/share/icingaweb2/public">
+     Options SymLinksIfOwnerMatch
+     AllowOverride None
+@@ -38,9 +45,11 @@ Alias /icingaweb2 "/usr/share/icingaweb2/public"
+         ErrorDocument 404 /icingaweb2/error_norewrite.html
+     </IfModule>
+ 
+-    # Forward PHP requests to FPM
+-    <FilesMatch "\.php$">
+-        SetHandler "proxy:fcgi://127.0.0.1:9000"
+-        ErrorDocument 503 /icingaweb2/error_unavailable.html
+-    </FilesMatch>
++    <IfVersion >= 2.4>
++        # Forward PHP requests to FPM
++        <FilesMatch "\.php$">
++            SetHandler "proxy:fcgi://127.0.0.1:9000"
++            ErrorDocument 503 /icingaweb2/error_unavailable.html
++        </FilesMatch>
++    </IfVersion>
+ </Directory>

--- a/icingaweb2/icingaweb2.spec
+++ b/icingaweb2/icingaweb2.spec
@@ -1,6 +1,6 @@
 # Icinga Web 2 | (c) 2013-2017 Icinga Development Team | GPLv2+
 
-%define revision 1
+%define revision 2
 
 Name:           icingaweb2
 Version:        2.5.0
@@ -11,6 +11,7 @@ License:        GPLv2+ and MIT and BSD
 URL:            https://icinga.com
 Source0:        https://github.com/Icinga/%{name}/archive/v%{version}.tar.gz
 Patch0:         icingaweb2-fix-apache-fpm-config.patch
+Patch1:         icingaweb2-fix-apache22-fpm-config.patch
 BuildArch:      noarch
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}
 Packager:       Icinga Team <info@icinga.com>
@@ -234,6 +235,7 @@ Icinga Web 2's fork of Zend Framework 1
 %prep
 %setup -q
 %patch0 -p1
+%patch1 -p1
 %if 0%{?use_selinux}
 mkdir selinux
 cp -p packages/selinux/icingaweb2.{fc,if,te} selinux
@@ -414,6 +416,9 @@ fi
 %{basedir}/library/vendor/Zend
 
 %changelog
+* Wed Nov 29 2017 Eric Lippmann <eric.lippmann@icinga.com> 2.5.0-2
+- FPM: Add patch to support both Apache >= 2.4 and Apache < 2.4
+
 * Tue Nov 28 2017 Eric Lippmann <eric.lippmann@icinga.com> 2.5.0-1
 - Install error_unavailable.html
 - Add patch to fix Apache FPM config

--- a/icingaweb2/icingaweb2.spec
+++ b/icingaweb2/icingaweb2.spec
@@ -10,6 +10,7 @@ Group:          Applications/System
 License:        GPLv2+ and MIT and BSD
 URL:            https://icinga.com
 Source0:        https://github.com/Icinga/%{name}/archive/v%{version}.tar.gz
+Patch0:         icingaweb2-fix-apache-fpm-config.patch
 BuildArch:      noarch
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}
 Packager:       Icinga Team <info@icinga.com>
@@ -232,6 +233,7 @@ Icinga Web 2's fork of Zend Framework 1
 
 %prep
 %setup -q
+%patch0 -p1
 %if 0%{?use_selinux}
 mkdir selinux
 cp -p packages/selinux/icingaweb2.{fc,if,te} selinux


### PR DESCRIPTION
Apache < 2.4 (RHEL and CentOS 6) does not support `SetHandler` in a `FilesMatch` block. The PR introduces `IfVersion` blocks to support FPM for both Apache >= 2.4 and Apache < 2.4.

fixes #72 