### PR TITLE
Require logrotate during build to allow su usage with newer versions

### DIFF
--- a/icinga2/icinga2.spec
+++ b/icinga2/icinga2.spec
@@ -169,6 +169,7 @@ Group:        System/Monitoring
 Requires(pre):  shadow-utils
 Requires(post): shadow-utils
 %endif
+BuildRequires:	logrotate
 %if "%{_vendor}" == "suse"
 Requires(pre):  shadow
 Requires(post): shadow


### PR DESCRIPTION
Following this commit
https://github.com/Icinga/icinga2/commit/4970c459ee9fa09c4ab92a2553824f2586fb77f5
logrotate needs to be available during build for the correct
configuration to be installed.