### PR TITLE
Icinga 2: addresses some linting errors

### DIFF
--- a/icinga2/icinga2.spec
+++ b/icinga2/icinga2.spec
@@ -53,7 +53,7 @@
 %endif
 
 %if "%{_vendor}" == "suse"
-%define plugindir %{_prefix}/lib/nagios/plugins
+%define plugindir %{_libexecdir}/nagios/plugins
 %define apachename apache2
 %define apacheconfdir  %{_sysconfdir}/apache2/conf.d
 %define apacheuser wwwrun
@@ -74,9 +74,6 @@
 %define icinga_user icinga
 %define icinga_group icinga
 %define icingacmd_group icingacmd
-%define icingaweb2name icingaweb2
-%define icingaweb2version 2.0.0
-
 
 %define logmsg logger -t %{name}/rpm
 
@@ -84,7 +81,7 @@ Summary: Network monitoring application
 Name: icinga2
 Version: 2.8.0
 Release: %{revision}%{?dist}
-License: GPL-2.0+
+License: GPLv2+
 URL: https://www.icinga.com/
 Group: System/Monitoring
 Source: https://github.com/Icinga/%{name}/archive/v%{version}.tar.gz
@@ -169,7 +166,7 @@ Group:        System/Monitoring
 Requires(pre):  shadow-utils
 Requires(post): shadow-utils
 %endif
-BuildRequires:	logrotate
+BuildRequires:  logrotate
 %if "%{_vendor}" == "suse"
 Requires(pre):  shadow
 Requires(post): shadow
@@ -367,7 +364,7 @@ cd -
 
 %install
 make install \
-	DESTDIR="%{buildroot}"
+        DESTDIR="%{buildroot}"
 
 # install custom limits.conf for systemd
 %if 0%{?configure_systemd_limits}
@@ -400,7 +397,7 @@ done
 cd -
 
 # TODO: Fix build problems on Icinga, see https://github.com/Icinga/puppet-icinga_build/issues/11
-#/usr/sbin/hardlink -cv %{buildroot}%{_datadir}/selinux
+#/usr/sbin/hardlink -cv %%{buildroot}%%{_datadir}/selinux
 %endif
 
 %if 0%{?fedora}
@@ -470,10 +467,10 @@ getent passwd %{icinga_user} >/dev/null || %{_sbindir}/useradd -c "icinga" -s /s
 
 if [ ${1:-0} -eq 1 ]
 then
-	# initial installation, enable default features
-	for feature in checker notification mainlog; do
-		ln -sf ../features-available/${feature}.conf %{_sysconfdir}/%{name}/features-enabled/${feature}.conf
-	done
+        # initial installation, enable default features
+        for feature in checker notification mainlog; do
+                ln -sf ../features-available/${feature}.conf %{_sysconfdir}/%{name}/features-enabled/${feature}.conf
+        done
 fi
 
 exit 0
@@ -489,10 +486,10 @@ exit 0
 
 if [ ${1:-0} -eq 1 ]
 then
-	# initial installation, enable default features
-	for feature in checker notification mainlog; do
-		ln -sf ../features-available/${feature}.conf %{_sysconfdir}/%{name}/features-enabled/${feature}.conf
-	done
+        # initial installation, enable default features
+        for feature in checker notification mainlog; do
+                ln -sf ../features-available/${feature}.conf %{_sysconfdir}/%{name}/features-enabled/${feature}.conf
+        done
 fi
 
 exit 0
@@ -517,7 +514,7 @@ exit 0
 %systemd_postun_with_restart %{name}.service
 %else
 if [ "$1" -ge  "1" ]; then
-	/sbin/service %{name} condrestart >/dev/null 2>&1 || :
+        /sbin/service %{name} condrestart >/dev/null 2>&1 || :
 fi
 %endif
 
@@ -525,8 +522,8 @@ fi
 # suse / rhel
 
 if [ "$1" = "0" ]; then
-	# deinstallation of the package - remove enabled features
-	rm -rf %{_sysconfdir}/%{name}/features-enabled
+        # deinstallation of the package - remove enabled features
+        rm -rf %{_sysconfdir}/%{name}/features-enabled
 fi
 
 exit 0
@@ -550,8 +547,8 @@ exit 0
 %systemd_preun %{name}.service
 %else
 if [ "$1" = "0" ]; then
-	/sbin/service %{name} stop > /dev/null 2>&1 || :
-	/sbin/chkconfig --del %{name} || :
+        /sbin/service %{name} stop > /dev/null 2>&1 || :
+        /sbin/chkconfig --del %{name} || :
 fi
 %endif
 
@@ -563,16 +560,16 @@ exit 0
 %post ido-mysql
 if [ ${1:-0} -eq 1 ]
 then
-	# initial installation, enable ido-mysql feature
-	ln -sf ../features-available/ido-mysql.conf %{_sysconfdir}/%{name}/features-enabled/ido-mysql.conf
+        # initial installation, enable ido-mysql feature
+        ln -sf ../features-available/ido-mysql.conf %{_sysconfdir}/%{name}/features-enabled/ido-mysql.conf
 fi
 
 exit 0
 
 %postun ido-mysql
 if [ "$1" = "0" ]; then
-	# deinstallation of the package - remove feature
-	rm -f %{_sysconfdir}/%{name}/features-enabled/ido-mysql.conf
+        # deinstallation of the package - remove feature
+        rm -f %{_sysconfdir}/%{name}/features-enabled/ido-mysql.conf
 fi
 
 exit 0
@@ -580,16 +577,16 @@ exit 0
 %post ido-pgsql
 if [ ${1:-0} -eq 1 ]
 then
-	# initial installation, enable ido-pgsql feature
-	ln -sf ../features-available/ido-pgsql.conf %{_sysconfdir}/%{name}/features-enabled/ido-pgsql.conf
+        # initial installation, enable ido-pgsql feature
+        ln -sf ../features-available/ido-pgsql.conf %{_sysconfdir}/%{name}/features-enabled/ido-pgsql.conf
 fi
 
 exit 0
 
 %postun ido-pgsql
 if [ "$1" = "0" ]; then
-	# deinstallation of the package - remove feature
-	rm -f %{_sysconfdir}/%{name}/features-enabled/ido-pgsql.conf
+        # deinstallation of the package - remove feature
+        rm -f %{_sysconfdir}/%{name}/features-enabled/ido-pgsql.conf
 fi
 
 exit 0
@@ -633,16 +630,6 @@ fi
 %exclude %{_datadir}/%{name}/include
 %{_mandir}/man8/%{name}.8.gz
 
-%attr(0750,%{icinga_user},%{icingacmd_group}) %{_localstatedir}/cache/%{name}
-%attr(0750,%{icinga_user},%{icingacmd_group}) %dir %{_localstatedir}/log/%{name}
-%attr(0750,%{icinga_user},%{icinga_group}) %dir %{_localstatedir}/log/%{name}/crash
-%attr(0750,%{icinga_user},%{icingacmd_group}) %dir %{_localstatedir}/log/%{name}/compat
-%attr(0750,%{icinga_user},%{icingacmd_group}) %dir %{_localstatedir}/log/%{name}/compat/archives
-%attr(0750,%{icinga_user},%{icinga_group}) %{_localstatedir}/lib/%{name}
-
-%attr(0750,%{icinga_user},%{icingacmd_group}) %ghost %{_rundir}/%{name}
-%attr(2750,%{icinga_user},%{icingacmd_group}) %ghost %{_rundir}/%{name}/cmd
-
 %files libs
 %defattr(-,root,root,-)
 %doc COPYING COPYING.Exceptions README.md NEWS AUTHORS CHANGELOG.md
@@ -654,7 +641,6 @@ fi
 %files common
 %defattr(-,root,root,-)
 %doc COPYING COPYING.Exceptions README.md NEWS AUTHORS CHANGELOG.md tools/syntax
-%attr(0750,%{icinga_user},%{icingacmd_group}) %dir %{_localstatedir}/log/%{name}
 %config(noreplace) %{_sysconfdir}/logrotate.d/%{name}
 %{_sysconfdir}/bash_completion.d/%{name}
 %if 0%{?use_systemd}
@@ -690,6 +676,14 @@ fi
 %dir %{_libexecdir}/%{name}
 %{_libexecdir}/%{name}/prepare-dirs
 %{_libexecdir}/%{name}/safe-reload
+%attr(0750,%{icinga_user},%{icingacmd_group}) %{_localstatedir}/cache/%{name}
+%attr(0750,%{icinga_user},%{icingacmd_group}) %dir %{_localstatedir}/log/%{name}
+%attr(0750,%{icinga_user},%{icinga_group}) %dir %{_localstatedir}/log/%{name}/crash
+%attr(0750,%{icinga_user},%{icingacmd_group}) %dir %{_localstatedir}/log/%{name}/compat
+%attr(0750,%{icinga_user},%{icingacmd_group}) %dir %{_localstatedir}/log/%{name}/compat/archives
+%attr(0750,%{icinga_user},%{icinga_group}) %{_localstatedir}/lib/%{name}
+%attr(0750,%{icinga_user},%{icingacmd_group}) %ghost %{_rundir}/%{name}
+%attr(2750,%{icinga_user},%{icingacmd_group}) %ghost %{_rundir}/%{name}/cmd
 %attr(0750,%{icinga_user},%{icinga_group}) %dir %{_localstatedir}/spool/%{name}
 %attr(0770,%{icinga_user},%{icinga_group}) %dir %{_localstatedir}/spool/%{name}/perfdata
 %attr(0750,%{icinga_user},%{icinga_group}) %dir %{_localstatedir}/spool/%{name}/tmp

--- a/icinga2/rpmlint/icinga2-bin.conf
+++ b/icinga2/rpmlint/icinga2-bin.conf
@@ -1,0 +1,6 @@
+# Groups are no longer used for osfamily RedHat, but we provide those for osfamily SUSE
+addFilter("W: non-standard-group .*")
+# Icinga is correct
+addFilter("W: spelling-error .* Icinga .*")
+# Subpackage is a common term for us
+addFilter("W: spelling-error .* subpackage .*")

--- a/icinga2/rpmlint/icinga2-common.conf
+++ b/icinga2/rpmlint/icinga2-common.conf
@@ -1,0 +1,31 @@
+# Groups are no longer used for osfamily RedHat, but we provide those for osfamily SUSE
+addFilter("W: non-standard-group .*")
+# Subpackage is a common term for us
+addFilter("W: spelling-error .* subpackage .*")
+# Permissions for icinga
+addFilter("W: non-standard-uid .* icinga")
+addFilter("W: non-standard-gid .* icinga")
+addFilter("W: non-standard-gid .* icingacmd")
+# Configuration could possibly contain passwords
+addFilter("E: non-readable /etc/icinga2/.*.conf (0)?640(L)?")
+addFilter("E: non-readable /etc/icinga2/zones.d/README (0)?640(L)?")
+# Because of permissions and configuration considerations all directories owned by icinga:icinga are made 750
+addFilter("E: non-standard-dir-perm .* (0)?750(L)?")
+addFilter("E: non-standard-dir-perm /run/icinga2/cmd (0)?2750(L)?")
+# Because of permissions and configuration considerations all directories owned by icinga:icingacmd are made 770
+addFilter("E: non-standard-dir-perm /var/spool/icinga2/perfdata (0)?770(L)?")
+# Notification scripts should be changed by user
+addFilter("E: executable-marked-as-config-file /etc/icinga2/scripts/.*")
+# Project prefers usage of env over the path for supporting multiple distributions, no reason to change this in packaging
+addFilter("E: wrong-script-interpreter /etc/icinga2/scripts/.* /usr/bin/env bash")
+# Bash-completion should not be changed by user
+addFilter("W: non-conffile-in-etc /etc/bash_completion.d/icinga2")
+# While placing systemd droplet into /usr/lib/systemd would be better /etc/systemd is considered more understandable for users
+addFilter("W: systemd-unit-in-etc /etc/systemd/system/icinga2.service.d.*")
+# Logrotate configuration is placed in common instead of the main package because icinga2 is only a metapackage
+addFilter("E: incoherent-logrotate-file /etc/logrotate.d/icinga2")
+# Feature installation
+addFilter("W: dangerous-command-in-%post ln")
+addFilter("W: dangerous-command-in-%postun rm")
+# Only scripts for initsystem in /usr/lib
+addFilter("W: only-non-binary-in-usr-lib")

--- a/icinga2/rpmlint/icinga2-debuginfo.conf
+++ b/icinga2/rpmlint/icinga2-debuginfo.conf
@@ -1,0 +1,4 @@
+# We decided to include third-party libraries
+addFilter("E: incorrect-fsf-address /usr/src/debug/icinga2-.*/third-party/.*")
+# Only debug-symbols in /usr/lib
+addFilter("W: only-non-binary-in-usr-lib")

--- a/icinga2/rpmlint/icinga2-doc.conf
+++ b/icinga2/rpmlint/icinga2-doc.conf
@@ -1,0 +1,4 @@
+# Groups are no longer used for osfamily RedHat, but we provide those for osfamily SUSE
+addFilter("W: non-standard-group .*")
+# Subpackage is a common term for us
+addFilter("W: spelling-error .* subpackage .*")

--- a/icinga2/rpmlint/icinga2-ido-mysql.conf
+++ b/icinga2/rpmlint/icinga2-ido-mysql.conf
@@ -1,0 +1,1 @@
+icinga2-ido.conf

--- a/icinga2/rpmlint/icinga2-ido-pgsql.conf
+++ b/icinga2/rpmlint/icinga2-ido-pgsql.conf
@@ -1,0 +1,1 @@
+icinga2-ido.conf

--- a/icinga2/rpmlint/icinga2-ido.conf
+++ b/icinga2/rpmlint/icinga2-ido.conf
@@ -1,0 +1,16 @@
+# Groups are no longer used for osfamily RedHat, but we provide those for osfamily SUSE
+addFilter("W: non-standard-group .*")
+# Icinga is correct
+addFilter("W: spelling-error .* Icinga .*")
+# Subpackage is a common term for us
+addFilter("W: spelling-error .* subpackage .*")
+# Permissions for icinga
+addFilter("W: non-standard-uid .* icinga")
+addFilter("W: non-standard-gid .* icinga")
+# File contains passwords
+addFilter("E: non-readable /etc/icinga2/features-available/ido-.*.conf (0)?640(L)?")
+# Feature installation
+addFilter("W: dangerous-command-in-%post ln")
+addFilter("W: dangerous-command-in-%postun rm")
+# This are runtime libraries and not for devel
+addFilter("W: devel-file-in-non-devel-package .*")

--- a/icinga2/rpmlint/icinga2-libs.conf
+++ b/icinga2/rpmlint/icinga2-libs.conf
@@ -1,0 +1,8 @@
+# Groups are no longer used for osfamily RedHat, but we provide those for osfamily SUSE
+addFilter("W: non-standard-group .*")
+# Subpackage is a common term for us
+addFilter("W: spelling-error .* subpackage .*")
+# This are runtime libraries and not for devel
+addFilter("W: devel-file-in-non-devel-package .*")
+# We decided to provide a more secure default and configuration file is not in the same package
+addFilter("W: crypto-policy-non-compliance-openssl /usr/lib64/icinga2/libbase.so.* SSL_CTX_set_cipher_list")

--- a/icinga2/rpmlint/icinga2-selinux.conf
+++ b/icinga2/rpmlint/icinga2-selinux.conf
@@ -1,0 +1,2 @@
+# Groups are no longer used for osfamily RedHat, but we provide those for osfamily SUSE
+addFilter("W: non-standard-group .*")

--- a/icinga2/rpmlint/icinga2-spec.conf
+++ b/icinga2/rpmlint/icinga2-spec.conf
@@ -1,0 +1,6 @@
+# Groups are no longer used for osfamily RedHat, but we provide those for osfamily SUSE
+addFilter("W: non-standard-group .*")
+# This is only for osfamily SUSE
+addFilter("W: unversioned-explicit-provides monitoring_daemon")
+# This is required for the plugins on distributons which not install in arch dependend path
+addFilter("E: hardcoded-library-path in %{_prefix}/lib/")

--- a/icinga2/rpmlint/icinga2-studio.conf
+++ b/icinga2/rpmlint/icinga2-studio.conf
@@ -1,0 +1,5 @@
+# Groups are no longer used for osfamily RedHat, but we provide those for osfamily SUSE
+addFilter("W: non-standard-group .*")
+# No separate documentation provided from upstream
+addFilter("W: no-documentation")
+addFilter("W: no-manual-page-for-binary icinga-studio")

--- a/icinga2/rpmlint/icinga2.conf
+++ b/icinga2/rpmlint/icinga2.conf
@@ -1,0 +1,4 @@
+# Groups are no longer used for osfamily RedHat, but we provide those for osfamily SUSE
+addFilter("W: non-standard-group .*")
+# It is only a meta-package
+addFilter("E: no-binary")

--- a/icinga2/rpmlint/nano-icinga2.conf
+++ b/icinga2/rpmlint/nano-icinga2.conf
@@ -1,0 +1,4 @@
+# Groups are no longer used for osfamily RedHat, but we provide those for osfamily SUSE
+addFilter("W: non-standard-group .*")
+# No separate documentation provided from upstream
+addFilter("W: no-documentation")

--- a/icinga2/rpmlint/vim-icinga2.conf
+++ b/icinga2/rpmlint/vim-icinga2.conf
@@ -1,0 +1,4 @@
+# Groups are no longer used for osfamily RedHat, but we provide those for osfamily SUSE
+addFilter("W: non-standard-group .*")
+# No separate documentation provided from upstream
+addFilter("W: no-documentation")


### PR DESCRIPTION
Icinga 2: addresses some linting errors  and adds configuration for validation

Files under rpmlint can be used with rpmlint -f to filter errors and warning. There is one file for the spec and one for every package which can be run as additional tests on build and installed packages which can show different issues. Every filter has a headline with the reason why it is introduced and acceptable, feel free to adjust the reason.

If the format is fine, I will create further pull requests for the other packages.